### PR TITLE
correção da URL do submódulo ui/freeboard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ui/freeboard"]
     path = ui/freeboard
-    url = git@github.com:joaodrj/freeboard.git
+    url = https://github.com/BIPES/freeboard
 [submodule "databoard"]
     path = databoard
     url = git@github.com:joaodrj/databoard.git


### PR DESCRIPTION
basta inicializar o submódulo com o comando
`
git submodule update --init ui/freeboard
` 