### PR TITLE
266 feat blocos pose aba visao

### DIFF
--- a/gesture-control/gesture-control.css
+++ b/gesture-control/gesture-control.css
@@ -105,6 +105,36 @@ body {
 .btn-ping:hover { background: #e8eaed; }
 .btn-ping:disabled { opacity: .55; cursor: not-allowed; }
 
+/* Toggle Mãos/Corpo */
+.mode-toggle {
+  display: inline-flex;
+  background: #f1f3f4;
+  border: 1px solid #dfe6e9;
+  border-radius: 8px;
+  padding: 2px;
+  gap: 2px;
+}
+.mode-opt {
+  border: none;
+  background: transparent;
+  padding: 0.3rem 0.75rem;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #636e72;
+  cursor: pointer;
+  transition: background .15s, color .15s, transform .1s;
+  white-space: nowrap;
+}
+.mode-opt:hover { color: #2d3436; }
+.mode-opt:active { transform: scale(.97); }
+.mode-opt.is-active {
+  background: #0984e3;
+  color: #fff;
+  box-shadow: 0 1px 2px rgba(9,132,227,.25);
+}
+.mode-opt:disabled { opacity: .5; cursor: not-allowed; }
+
 /* Indicador AO VIVO */
 .rec-indicator {
   display: flex;

--- a/gesture-control/gesture-control.css
+++ b/gesture-control/gesture-control.css
@@ -117,9 +117,9 @@ body {
 .mode-opt {
   border: none;
   background: transparent;
-  padding: 0.3rem 0.75rem;
+  padding: 0.5rem 1.1rem;
   border-radius: 6px;
-  font-size: 13px;
+  font-size: 15px;
   font-weight: 600;
   color: #636e72;
   cursor: pointer;

--- a/gesture-control/gesture-control.js
+++ b/gesture-control/gesture-control.js
@@ -156,8 +156,8 @@ function applyModeUI() {
     ? '⚙ Mapeamento de Poses'
     : '⚙ Mapeamento de Gestos';
   if (modalDesc) modalDesc.textContent = mode === 'pose'
-    ? 'Configure o endpoint HTTP enviado ao ESP32 para cada pose corporal detectada.'
-    : 'Configure o endpoint HTTP enviado ao ESP32 para cada gesto reconhecido.';
+    ? 'Configure o endpoint HTTP enviado ao AMADOBOARD para cada pose corporal detectada.'
+    : 'Configure o endpoint HTTP enviado ao AMADOBOARD para cada gesto reconhecido.';
 }
 
 async function setMode(next) {
@@ -285,9 +285,9 @@ function buildCards() {
 
     const input = document.createElement('input');
     input.type = 'text';
-    input.placeholder = defaultEndpointFor(g.key) || '/comando';
+    input.placeholder = '/comando';
     input.value = mappings[g.key] || '';
-    input.title = 'Endpoint HTTP — ex: ' + (defaultEndpointFor(g.key) || '/led/on');
+    input.title = 'Endpoint HTTP — ex: /led/on';
     input.addEventListener('change', e => {
       setMapping(g.key, e.target.value.trim());
       card.classList.toggle('empty-hint', !e.target.value.trim());
@@ -696,7 +696,7 @@ function sendCommand(gesture) {
   const mapping = userMapping || defaultEndpointFor(gesture);
 
   if (!mapping) return;
-  if (!ip) { setStatus('err', 'Configure o IP do ESP32'); return; }
+  if (!ip) { setStatus('err', 'Configure o IP do AMADOBOARD'); return; }
 
   const endpoint = mapping.startsWith('/') ? mapping : '/' + mapping;
   const url = 'http://' + ip + endpoint;
@@ -707,7 +707,7 @@ function sendCommand(gesture) {
       flashCard(gesture);
     })
     .catch(() => {
-      setStatus('err', 'Sem resposta do ESP32');
+      setStatus('err', 'Sem resposta do AMADOBOARD');
     });
 }
 

--- a/gesture-control/gesture-control.js
+++ b/gesture-control/gesture-control.js
@@ -14,6 +14,17 @@ const GESTURES = [
   { key: 'ILoveYou',   label: 'Eu te amo',       emoji: '🤟' },
 ];
 
+// Poses corporais (MediaPipe Pose, 33 landmarks).
+// Chaves batem com `when_pose_detected` no Blockly e com /pose/<key> no ESP32.
+const POSES = [
+  { key: 'arms_up',        label: 'Braços para cima',     emoji: '🙌' },
+  { key: 't_pose',         label: 'Braços abertos (T)',   emoji: '🕴' },
+  { key: 'right_arm_up',   label: 'Braço direito',         emoji: '🫱' },
+  { key: 'left_arm_up',    label: 'Braço esquerdo',        emoji: '🫲' },
+  { key: 'hands_on_head',  label: 'Mãos na cabeça',        emoji: '🙆' },
+  { key: 'arms_crossed',   label: 'Braços cruzados',       emoji: '🙅' },
+];
+
 // Conexões padrão da mão no MediaPipe (21 landmarks)
 const HAND_CONNECTIONS = [
   [0,1],[1,2],[2,3],[3,4],
@@ -23,19 +34,46 @@ const HAND_CONNECTIONS = [
   [13,17],[0,17],[17,18],[18,19],[19,20],
 ];
 
-const KEY_IP        = 'gesture_esp32_ip';
-const KEY_MAPPINGS  = 'gesture_mappings';
-const DEBOUNCE_MS   = 700;
-const CONFIDENCE    = 0.75;
-const MEDIAPIPE_URL = 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/vision_bundle.mjs';
+// Esqueleto de pose: tronco + braços + pernas
+const POSE_CONNECTIONS = [
+  [11,12],[11,23],[12,24],[23,24],
+  [11,13],[13,15],
+  [12,14],[14,16],
+  [23,25],[25,27],
+  [24,26],[26,28],
+];
 
-let recognizer           = null;
+// Índices dos landmarks MediaPipe Pose (do ponto de vista do sujeito)
+const LM = {
+  NOSE: 0,
+  L_SHOULDER: 11, R_SHOULDER: 12,
+  L_ELBOW: 13,    R_ELBOW: 14,
+  L_WRIST: 15,    R_WRIST: 16,
+  L_HIP: 23,      R_HIP: 24,
+  L_KNEE: 25,     R_KNEE: 26,
+};
+
+const KEY_IP             = 'gesture_esp32_ip';
+const KEY_MAPPINGS       = 'gesture_mappings';
+const KEY_POSE_MAPPINGS  = 'pose_mappings';
+const KEY_MODE           = 'vision_mode';   // 'hands' | 'pose'
+const DEBOUNCE_MS        = 700;
+const CONFIDENCE         = 0.75;
+const POSE_HOLD_MS       = 250;             // pose precisa estabilizar antes de disparar
+const MEDIAPIPE_URL      = 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/vision_bundle.mjs';
+const POSE_MODEL_URL     = 'https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/latest/pose_landmarker_lite.task';
+
+let recognizer           = null;   // GestureRecognizer (modo Mãos)
+let poseLandmarker       = null;   // PoseLandmarker    (modo Corpo)
 let stream               = null;
 let rafId                = null;
 let isRunning            = false;
-let lastGesture          = '';
+let lastGesture          = '';     // último gesto OU pose disparado (compartilhado)
 let lastSentAt           = 0;
 let GestureRecognizerClass = null;
+let mode                 = 'hands';  // 'hands' | 'pose'
+let poseHoldKey          = null;     // pose atualmente "segurada"
+let poseHoldSince        = 0;
 
 // ── DOM ──────────────────────────────────────────────────────
 const ipInput       = document.getElementById('ipInput');
@@ -67,10 +105,16 @@ const btnPing       = document.getElementById('btnPing');
 const modalBackdrop = document.getElementById('modalBackdrop');
 const btnMappings   = document.getElementById('btnMappings');
 const btnCloseModal = document.getElementById('btnCloseModal');
+const modalTitle    = document.getElementById('modalTitle');
+const modalDesc     = document.getElementById('modalDesc');
+const btnModeHands  = document.getElementById('modeHands');
+const btnModePose   = document.getElementById('modePose');
 
 // ── Init ─────────────────────────────────────────────────────
 function init() {
   ipInput.value = localStorage.getItem(KEY_IP) || '';
+  mode = localStorage.getItem(KEY_MODE) === 'pose' ? 'pose' : 'hands';
+  applyModeUI();
   updateStatus();
   buildCards();
 
@@ -89,6 +133,9 @@ function init() {
     if (e.key === 'Escape') closeModal();
   });
 
+  btnModeHands.addEventListener('click', () => setMode('hands'));
+  btnModePose .addEventListener('click', () => setMode('pose'));
+
   // Libera câmera ao fechar/navegar
   window.addEventListener('beforeunload', () => {
     if (isRunning) window.stopCamera();
@@ -96,6 +143,47 @@ function init() {
 
   // Atualiza canvas quando a janela for redimensionada
   new ResizeObserver(syncCanvasSize).observe(videoWrapper);
+}
+
+// ── Modo (Mãos/Corpo) ─────────────────────────────────────────
+function applyModeUI() {
+  btnModeHands.classList.toggle('is-active', mode === 'hands');
+  btnModePose .classList.toggle('is-active', mode === 'pose');
+
+  // Botão do HUD e cabeçalho do modal refletem o modo
+  btnMappings.textContent = mode === 'pose' ? '⚙ Definir Poses' : '⚙ Definir Gestos';
+  if (modalTitle) modalTitle.textContent = mode === 'pose'
+    ? '⚙ Mapeamento de Poses'
+    : '⚙ Mapeamento de Gestos';
+  if (modalDesc) modalDesc.textContent = mode === 'pose'
+    ? 'Configure o endpoint HTTP enviado ao ESP32 para cada pose corporal detectada.'
+    : 'Configure o endpoint HTTP enviado ao ESP32 para cada gesto reconhecido.';
+}
+
+async function setMode(next) {
+  if (mode === next) return;
+  mode = next;
+  localStorage.setItem(KEY_MODE, mode);
+  applyModeUI();
+  buildCards();
+  resetLiveUI();
+
+  if (!isRunning) return;
+
+  // Câmera ligada: swap de modelo sem desligar a câmera
+  try {
+    showOverlay('Trocando modelo de detecção...');
+    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+    if (recognizer)     { recognizer.close();     recognizer     = null; }
+    if (poseLandmarker) { poseLandmarker.close(); poseLandmarker = null; }
+    await loadDetectorForMode();
+    hideOverlay();
+    detectLoop();
+  } catch (err) {
+    hideOverlay();
+    setStatus('err', 'Erro ao trocar modo: ' + err.message);
+    console.error(err);
+  }
 }
 
 function saveIp() {
@@ -137,29 +225,44 @@ function setStatus(state, msg) {
 function openModal()  { modalBackdrop.classList.remove('hidden'); }
 function closeModal() { modalBackdrop.classList.add('hidden'); }
 
-// ── Cards ─────────────────────────────────────────────────────
+// ── Mapeamentos (gesto OU pose, escolhido pelo modo atual) ────
+function currentMappingKey() {
+  return mode === 'pose' ? KEY_POSE_MAPPINGS : KEY_MAPPINGS;
+}
+
+function currentItems() {
+  return mode === 'pose' ? POSES : GESTURES;
+}
+
+function defaultEndpointFor(key) {
+  return mode === 'pose' ? '/pose/' + key : '';
+}
+
 function getMappings() {
-  try { return JSON.parse(localStorage.getItem(KEY_MAPPINGS) || '{}'); }
+  try { return JSON.parse(localStorage.getItem(currentMappingKey()) || '{}'); }
   catch { return {}; }
 }
 
 function setMapping(key, val) {
   const m = getMappings();
   m[key] = val;
-  localStorage.setItem(KEY_MAPPINGS, JSON.stringify(m));
+  localStorage.setItem(currentMappingKey(), JSON.stringify(m));
   updateMappedCount();
 }
 
 function updateMappedCount() {
+  const items = currentItems();
   const count = Object.values(getMappings()).filter(v => v).length;
-  hudMappedEl.textContent = count + '/' + GESTURES.length + ' gestos mapeados';
+  const label = mode === 'pose' ? 'poses' : 'gestos';
+  hudMappedEl.textContent = count + '/' + items.length + ' ' + label + ' mapeados';
 }
 
 function buildCards() {
   const mappings = getMappings();
+  const items    = currentItems();
   cardsGrid.innerHTML = '';
   updateMappedCount();
-  GESTURES.forEach(g => {
+  items.forEach(g => {
     const card = document.createElement('div');
     card.className = 'g-card' + (mappings[g.key] ? '' : ' empty-hint');
     card.id = 'card_' + g.key;
@@ -182,9 +285,9 @@ function buildCards() {
 
     const input = document.createElement('input');
     input.type = 'text';
-    input.placeholder = '/comando';
+    input.placeholder = defaultEndpointFor(g.key) || '/comando';
     input.value = mappings[g.key] || '';
-    input.title = 'Endpoint HTTP — ex: /led/on';
+    input.title = 'Endpoint HTTP — ex: ' + (defaultEndpointFor(g.key) || '/led/on');
     input.addEventListener('change', e => {
       setMapping(g.key, e.target.value.trim());
       card.classList.toggle('empty-hint', !e.target.value.trim());
@@ -194,6 +297,13 @@ function buildCards() {
     card.append(badge, emoji, name, wrap);
     cardsGrid.appendChild(card);
   });
+}
+
+function resetLiveUI() {
+  lastGesture = '';
+  poseHoldKey = null;
+  poseHoldSince = 0;
+  updateLiveUI(null, 0);
 }
 
 // ── Ping ESP32 ────────────────────────────────────────────────
@@ -249,18 +359,32 @@ async function loadMP() {
   return _mp;
 }
 
-async function startCamera() {
-  if (isRunning) return;
-  btnStart.disabled = true;
+async function loadDetectorForMode() {
+  const mp = await loadMP();
+  const { GestureRecognizer, PoseLandmarker, FilesetResolver } = mp;
+  const vision = await FilesetResolver.forVisionTasks(
+    'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/wasm'
+  );
 
-  try {
-    showOverlay('Carregando MediaPipe...');
-    const { GestureRecognizer, FilesetResolver } = await loadMP();
-
-    showOverlay('Inicializando reconhecedor...');
-    const vision = await FilesetResolver.forVisionTasks(
-      'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/wasm'
-    );
+  if (mode === 'pose') {
+    showOverlay('Carregando modelo de pose...');
+    if (!PoseLandmarker) throw new Error('PoseLandmarker indisponível neste bundle MediaPipe');
+    try {
+      poseLandmarker = await PoseLandmarker.createFromOptions(vision, {
+        baseOptions: { modelAssetPath: POSE_MODEL_URL, delegate: 'GPU' },
+        runningMode: 'VIDEO',
+        numPoses: 1,
+      });
+    } catch (_) {
+      showOverlay('GPU indisponível, usando CPU...');
+      poseLandmarker = await PoseLandmarker.createFromOptions(vision, {
+        baseOptions: { modelAssetPath: POSE_MODEL_URL, delegate: 'CPU' },
+        runningMode: 'VIDEO',
+        numPoses: 1,
+      });
+    }
+  } else {
+    showOverlay('Carregando modelo de gestos...');
     const modelAssetPath = 'https://storage.googleapis.com/mediapipe-models/gesture_recognizer/gesture_recognizer/float16/1/gesture_recognizer.task';
     try {
       recognizer = await GestureRecognizer.createFromOptions(vision, {
@@ -276,6 +400,16 @@ async function startCamera() {
         numHands: 1,
       });
     }
+  }
+}
+
+async function startCamera() {
+  if (isRunning) return;
+  btnStart.disabled = true;
+
+  try {
+    showOverlay('Carregando MediaPipe...');
+    await loadDetectorForMode();
 
     showOverlay('Acessando câmera...');
     stream = await navigator.mediaDevices.getUserMedia({
@@ -316,7 +450,8 @@ window.stopCamera = function stopCamera() {
   isRunning = false;
   if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
   if (stream) { stream.getTracks().forEach(t => t.stop()); stream = null; }
-  if (recognizer) { recognizer.close(); recognizer = null; }
+  if (recognizer)     { recognizer.close();     recognizer     = null; }
+  if (poseLandmarker) { poseLandmarker.close(); poseLandmarker = null; }
 
   videoEl.srcObject = null;
   ctx.clearRect(0, 0, canvasEl.width, canvasEl.height);
@@ -330,25 +465,53 @@ window.stopCamera = function stopCamera() {
   hudCmdEl.textContent = '';
   recIndicator.classList.add('hidden');
 
-  updateGestureUI('None', 0);
+  updateLiveUI(null, 0);
+  poseHoldKey = null;
+  poseHoldSince = 0;
   updateStatus();
 };
 
 function detectLoop() {
-  if (!isRunning || !recognizer) return;
+  if (!isRunning) return;
 
   if (videoEl.readyState >= 2) {
-    const results = recognizer.recognizeForVideo(videoEl, performance.now());
     ctx.clearRect(0, 0, canvasEl.width, canvasEl.height);
-    try { drawHandLandmarks(results); } catch (_) { /* erros de desenho não param o loop */ }
 
-    if (results.gestures?.length) {
-      const top = results.gestures[0][0];
-      updateGestureUI(top.categoryName, top.score);
-      if (top.categoryName !== 'None' && top.score >= CONFIDENCE)
-        maybeDispatch(top.categoryName);
-    } else {
-      updateGestureUI('None', 0);
+    if (mode === 'pose' && poseLandmarker) {
+      try {
+        const results = poseLandmarker.detectForVideo(videoEl, performance.now());
+        drawPoseLandmarks(results);
+        const lm = results.landmarks?.[0];
+        const detected = lm ? evaluatePose(lm) : null;
+
+        if (detected) {
+          // exige hold para evitar pisca-pisca
+          if (poseHoldKey !== detected) {
+            poseHoldKey = detected;
+            poseHoldSince = performance.now();
+          }
+          const held = performance.now() - poseHoldSince;
+          updateLiveUI(detected, Math.min(1, held / POSE_HOLD_MS));
+          if (held >= POSE_HOLD_MS) maybeDispatch(detected);
+        } else {
+          poseHoldKey = null;
+          poseHoldSince = 0;
+          updateLiveUI(null, 0);
+        }
+      } catch (err) { console.error('Pose detect:', err); }
+
+    } else if (mode === 'hands' && recognizer) {
+      const results = recognizer.recognizeForVideo(videoEl, performance.now());
+      try { drawHandLandmarks(results); } catch (_) { /* erros de desenho não param o loop */ }
+
+      if (results.gestures?.length) {
+        const top = results.gestures[0][0];
+        updateLiveUI(top.categoryName, top.score);
+        if (top.categoryName !== 'None' && top.score >= CONFIDENCE)
+          maybeDispatch(top.categoryName);
+      } else {
+        updateLiveUI(null, 0);
+      }
     }
   }
 
@@ -394,11 +557,106 @@ function drawHandLandmarks(results) {
   }
 }
 
-// ── Gesture UI ────────────────────────────────────────────────
-function updateGestureUI(key, conf) {
-  const g = GESTURES.find(x => x.key === key);
+// Desenho do esqueleto de pose
+function drawPoseLandmarks(results) {
+  const lm = results.landmarks?.[0];
+  if (!lm) return;
+  const { ox, oy, rw, rh } = getCoverRect();
+  const pts = lm.map(p => ({ x: ox + p.x * rw, y: oy + p.y * rh }));
 
-  if (!g) {
+  ctx.strokeStyle = 'rgba(155, 89, 182, 0.9)';
+  ctx.lineWidth   = 3;
+  ctx.lineCap     = 'round';
+  for (const [s, e] of POSE_CONNECTIONS) {
+    if (!pts[s] || !pts[e]) continue;
+    ctx.beginPath();
+    ctx.moveTo(pts[s].x, pts[s].y);
+    ctx.lineTo(pts[e].x, pts[e].y);
+    ctx.stroke();
+  }
+  const keyPoints = [0, 11, 12, 13, 14, 15, 16, 23, 24, 25, 26];
+  for (const i of keyPoints) {
+    if (!pts[i]) continue;
+    ctx.beginPath();
+    ctx.arc(pts[i].x, pts[i].y, 5, 0, Math.PI * 2);
+    ctx.fillStyle   = '#a29bfe';
+    ctx.fill();
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth   = 1.5;
+    ctx.stroke();
+  }
+}
+
+// Avalia regras simples sobre os 33 landmarks e devolve a chave da
+// pose ativa (ou null). Coordenadas são normalizadas [0..1]; y cresce
+// para BAIXO, então "para cima" = y menor.
+function evaluatePose(lm) {
+  if (!lm || lm.length < 17) return null;
+
+  const ls = lm[LM.L_SHOULDER], rs = lm[LM.R_SHOULDER];
+  const lw = lm[LM.L_WRIST],    rw = lm[LM.R_WRIST];
+  const nose = lm[LM.NOSE];
+
+  // Precisamos pelo menos dos dois ombros e do nariz pra ter referencial.
+  const vis = p => (p.visibility ?? 1);
+  if (vis(ls) < 0.5 || vis(rs) < 0.5 || vis(nose) < 0.5) return null;
+
+  // Visibilidade dos pulsos avaliada por LADO — assim um pulso oculto
+  // do outro lado não derruba a detecção do lado bom.
+  const leftWristVisible  = vis(lw) > 0.4;
+  const rightWristVisible = vis(rw) > 0.4;
+
+  // Unidade de referência: largura entre ombros (proporcional ao tamanho
+  // do corpo na imagem; funciona perto e longe da câmera).
+  const shoulderW = Math.hypot(ls.x - rs.x, ls.y - rs.y) || 0.1;
+  const upMargin  = shoulderW * 0.15;
+  const tolY      = shoulderW * 0.30;
+
+  const leftWristUp  = leftWristVisible  && lw.y < ls.y - upMargin;
+  const rightWristUp = rightWristVisible && rw.y < rs.y - upMargin;
+
+  const leftAtShoulder  = leftWristVisible  && Math.abs(lw.y - ls.y) < tolY && Math.abs(lw.x - ls.x) > shoulderW * 0.7;
+  const rightAtShoulder = rightWristVisible && Math.abs(rw.y - rs.y) < tolY && Math.abs(rw.x - rs.x) > shoulderW * 0.7;
+
+  // "Mãos na cabeça": pulso PERTO do nariz (raio ~ largura da cabeça)
+  // E não muito acima dele — se estiver muito acima, é "braços pra cima".
+  const HEAD_RADIUS = shoulderW * 0.55;
+  const HEAD_ABOVE_LIMIT = shoulderW * 0.25; // o quanto o pulso pode ficar acima do nariz
+  const handOnHead = (w, visible) =>
+    visible &&
+    Math.hypot(w.x - nose.x, w.y - nose.y) < HEAD_RADIUS &&
+    w.y > nose.y - HEAD_ABOVE_LIMIT;
+  const leftHandOnHead  = handOnHead(lw, leftWristVisible);
+  const rightHandOnHead = handOnHead(rw, rightWristVisible);
+
+  // "Braços cruzados no peito": cada pulso fica mais perto do ombro OPOSTO
+  // (sinal claro de cruzamento) e ambos estão na altura do peito (abaixo
+  // dos ombros, mas não muito abaixo).
+  const dist2 = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
+  const lwCrossed = leftWristVisible  && dist2(lw, rs) < dist2(lw, ls);
+  const rwCrossed = rightWristVisible && dist2(rw, ls) < dist2(rw, rs);
+  const chestLevel = (w, s) => w.y > s.y - upMargin && w.y < s.y + shoulderW * 1.2;
+  const armsCrossed =
+    lwCrossed && rwCrossed &&
+    chestLevel(lw, ls) && chestLevel(rw, rs);
+
+  // Ordem importa: poses mais específicas antes das genéricas.
+  if (leftHandOnHead && rightHandOnHead) return 'hands_on_head';
+  if (armsCrossed) return 'arms_crossed';
+  if (leftWristUp && rightWristUp) return 'arms_up';
+  if (leftAtShoulder && rightAtShoulder) return 't_pose';
+  // do ponto de vista do sujeito: braço direito = R_WRIST (16)
+  if (rightWristUp && !leftWristUp) return 'right_arm_up';
+  if (leftWristUp && !rightWristUp) return 'left_arm_up';
+
+  return null;
+}
+
+// ── UI ao vivo (compartilhada por gestos e poses) ─────────────
+function updateLiveUI(key, conf) {
+  const item = currentItems().find(x => x.key === key);
+
+  if (!item) {
     liveEmoji.textContent = '—';
     liveName.textContent  = 'AGUARDANDO';
     liveName.className    = 'live-name none';
@@ -406,17 +664,18 @@ function updateGestureUI(key, conf) {
     confBar.style.width   = '0%';
     gcWrap.classList.remove('active');
   } else {
-    liveEmoji.textContent = g.emoji;
-    liveName.textContent  = g.label.toUpperCase();
+    liveEmoji.textContent = item.emoji;
+    liveName.textContent  = item.label.toUpperCase();
     liveName.className    = 'live-name';
     liveConf.textContent  = 'CONFIANÇA: ' + Math.round(conf * 100) + '%';
     confBar.style.width   = Math.round(conf * 100) + '%';
-    confBar.style.background = conf >= CONFIDENCE ? '#00b894' : '#00cec9';
+    confBar.style.background = conf >= (mode === 'pose' ? 1 : CONFIDENCE)
+      ? '#00b894' : '#00cec9';
     gcWrap.classList.add('active');
   }
 
   document.querySelectorAll('.g-card').forEach(c => c.classList.remove('active'));
-  if (g) document.getElementById('card_' + key)?.classList.add('active');
+  if (item) document.getElementById('card_' + key)?.classList.add('active');
 }
 
 // ── HTTP dispatch ─────────────────────────────────────────────
@@ -430,7 +689,11 @@ function maybeDispatch(gesture) {
 
 function sendCommand(gesture) {
   const ip      = ipInput.value.trim();
-  const mapping = getMappings()[gesture] || '';
+  // No modo "pose", o endpoint padrão é /pose/<key> (bate com o
+  // bloco when_pose_detected no ESP32); o aluno pode sobrescrever
+  // no modal. No modo "hands", sem mapeamento = nada a enviar.
+  const userMapping = getMappings()[gesture] || '';
+  const mapping = userMapping || defaultEndpointFor(gesture);
 
   if (!mapping) return;
   if (!ip) { setStatus('err', 'Configure o IP do ESP32'); return; }

--- a/gesture-control/gesture-control.js
+++ b/gesture-control/gesture-control.js
@@ -15,7 +15,8 @@ const GESTURES = [
 ];
 
 // Poses corporais (MediaPipe Pose, 33 landmarks).
-// Chaves batem com `when_pose_detected` no Blockly e com /pose/<key> no ESP32.
+// Chaves batem com `when_pose_detected`/`when_gesture_detected` no Blockly
+// e com /pose/<key> ou /gesture/<key> na AMADOBOARD.
 const POSES = [
   { key: 'arms_up',        label: 'Braços para cima',     emoji: '🙌' },
   { key: 't_pose',         label: 'Braços abertos (T)',   emoji: '🕴' },
@@ -235,7 +236,7 @@ function currentItems() {
 }
 
 function defaultEndpointFor(key) {
-  return mode === 'pose' ? '/pose/' + key : '';
+  return mode === 'pose' ? '/pose/' + key : '/gesture/' + key;
 }
 
 function getMappings() {

--- a/gesture-control/index.html
+++ b/gesture-control/index.html
@@ -17,7 +17,7 @@
   <div class="topbar">
 
     <div class="ip-group">
-      <label for="ipInput">ESP32 IP:</label>
+      <label for="ipInput">AMADOBOARD IP:</label>
       <input type="text" id="ipInput" placeholder="192.168.1.100" autocomplete="off" spellcheck="false">
       <button class="btn btn-save" id="btnSave">Salvar</button>
       <button class="btn btn-ping" id="btnPing">⚡ Testar</button>
@@ -77,9 +77,9 @@
           <div class="hfc hfc-bl"></div>
           <div class="hfc hfc-br"></div>
 
-          <!-- Topo-esquerdo: status ESP32 -->
+          <!-- Topo-esquerdo: status AMADOBOARD -->
           <div class="hud-panel hud-tl">
-            <div class="hp-label">ESP32</div>
+            <div class="hp-label">AMADOBOARD</div>
             <div class="hp-value" id="hudIp">—</div>
             <div class="hp-sub" id="hudCmd"></div>
             <div class="hp-divider"></div>
@@ -117,7 +117,7 @@
         <span class="modal-title" id="modalTitle">⚙ Mapeamento de Gestos</span>
         <button class="modal-close" id="btnCloseModal">✕</button>
       </div>
-      <p class="modal-desc" id="modalDesc">Configure o endpoint HTTP enviado ao ESP32 para cada gesto reconhecido.</p>
+      <p class="modal-desc" id="modalDesc">Configure o endpoint HTTP enviado ao AMADOBOARD para cada gesto reconhecido.</p>
       <div class="cards-grid" id="cardsGrid"></div>
     </div>
   </div>

--- a/gesture-control/index.html
+++ b/gesture-control/index.html
@@ -35,6 +35,11 @@
 
     <div class="spacer"></div>
 
+    <div class="mode-toggle" role="radiogroup" aria-label="Modo de detecção">
+      <button class="mode-opt is-active" id="modeHands" data-mode="hands" type="button">✋ Mãos</button>
+      <button class="mode-opt"           id="modePose"  data-mode="pose"  type="button">🧍 Corpo</button>
+    </div>
+
     <button class="btn btn-cam-on"  id="btnStart">▶ Ligar Câmera</button>
     <button class="btn btn-cam-off" id="btnStop" disabled>■ Desligar</button>
   </div>
@@ -67,7 +72,7 @@
           <div class="hfc hfc-tl"></div>
           <div class="hfc hfc-tr"></div>
 
-          <!-- Topo-direito: botão definir gestos -->
+          <!-- Topo-direito: botão definir mapeamentos (texto muda conforme modo) -->
           <button class="hud-btn-gestos" id="btnMappings">⚙ Definir Gestos</button>
           <div class="hfc hfc-bl"></div>
           <div class="hfc hfc-br"></div>
@@ -109,10 +114,10 @@
   <div class="modal-backdrop hidden" id="modalBackdrop">
     <div class="modal">
       <div class="modal-header">
-        <span class="modal-title">⚙ Mapeamento de Gestos</span>
+        <span class="modal-title" id="modalTitle">⚙ Mapeamento de Gestos</span>
         <button class="modal-close" id="btnCloseModal">✕</button>
       </div>
-      <p class="modal-desc">Configure o endpoint HTTP enviado ao ESP32 para cada gesto reconhecido.</p>
+      <p class="modal-desc" id="modalDesc">Configure o endpoint HTTP enviado ao ESP32 para cada gesto reconhecido.</p>
       <div class="cards-grid" id="cardsGrid"></div>
     </div>
   </div>

--- a/gesture-control/index.html
+++ b/gesture-control/index.html
@@ -20,7 +20,7 @@
       <label for="ipInput">AMADOBOARD IP:</label>
       <input type="text" id="ipInput" placeholder="192.168.1.100" autocomplete="off" spellcheck="false">
       <button class="btn btn-save" id="btnSave">Salvar</button>
-      <button class="btn btn-ping" id="btnPing">⚡ Testar</button>
+      <button class="btn btn-ping" id="btnPing">Testar</button>
     </div>
 
     <div id="statusChip" class="status-chip">
@@ -36,8 +36,8 @@
     <div class="spacer"></div>
 
     <div class="mode-toggle" role="radiogroup" aria-label="Modo de detecção">
-      <button class="mode-opt is-active" id="modeHands" data-mode="hands" type="button">✋ Mãos</button>
-      <button class="mode-opt"           id="modePose"  data-mode="pose"  type="button">🧍 Corpo</button>
+      <button class="mode-opt is-active" id="modeHands" data-mode="hands" type="button">Mãos</button>
+      <button class="mode-opt"           id="modePose"  data-mode="pose"  type="button">Corpo</button>
     </div>
 
     <button class="btn btn-cam-on"  id="btnStart">▶ Ligar Câmera</button>

--- a/ui/b.msg/js/en.js
+++ b/ui/b.msg/js/en.js
@@ -558,3 +558,4 @@ Blockly.Msg["ACTUATORS_HUE"] = "#708090";
 Blockly.Msg["COMM_HUE"] = "#4B0082";
 Blockly.Msg["NET_HUE"] = "#4B0082";
 Blockly.Msg["SUB_NET_HUE"] = "#a278d1";
+Blockly.Msg["VISION_HUE"] = "#0984e3";

--- a/ui/b.msg/js/es.js
+++ b/ui/b.msg/js/es.js
@@ -561,3 +561,4 @@ Blockly.Msg["ACTUATORS_HUE"] = "#708090";
 Blockly.Msg["COMM_HUE"] = "#4B0082";
 Blockly.Msg["NET_HUE"] = "#4B0082";
 Blockly.Msg["SUB_NET_HUE"] = "#a278d1";
+Blockly.Msg["VISION_HUE"] = "#0984e3";

--- a/ui/b.msg/js/pt-br.js
+++ b/ui/b.msg/js/pt-br.js
@@ -555,3 +555,4 @@ Blockly.Msg["ACTUATORS_HUE"] = "#708090";
 Blockly.Msg["COMM_HUE"] = "#4B0082";
 Blockly.Msg["NET_HUE"] = "#4B0082";
 Blockly.Msg["SUB_NET_HUE"] = "#a278d1";
+Blockly.Msg["VISION_HUE"] = "#0984e3";

--- a/ui/b.msg/js/pt.js
+++ b/ui/b.msg/js/pt.js
@@ -814,3 +814,4 @@ Blockly.Msg["ACTUATORS_HUE"] = "#708090";
 Blockly.Msg["COMM_HUE"] = "#4B0082";
 Blockly.Msg["NET_HUE"] = "#4B0082";
 Blockly.Msg["SUB_NET_HUE"] = "#a278d1";
+Blockly.Msg["VISION_HUE"] = "#0984e3";

--- a/ui/core/block_definitions.js
+++ b/ui/core/block_definitions.js
@@ -12633,8 +12633,8 @@ Blockly.Blocks['create_list_with_repeated'] = {
 };
 
 
-// ── Visão (Pose) ─────────────────────────────────────────────
-// Lista única de poses — mesmas chaves usadas no gerador Python
+// ── Visão (Pose + Gesto) ─────────────────────────────────────
+// Listas únicas — mesmas chaves usadas no gerador Python
 // e no motor de detecção (gesture-control.js).
 const POSE_OPTIONS = [
   ['pose_arms_up',        'arms_up'],
@@ -12643,6 +12643,16 @@ const POSE_OPTIONS = [
   ['pose_left_arm_up',    'left_arm_up'],
   ['pose_hands_on_head',  'hands_on_head'],
   ['pose_arms_crossed',   'arms_crossed'],
+];
+
+const GESTURE_OPTIONS = [
+  ['gesture_closed_fist', 'Closed_Fist'],
+  ['gesture_open_palm',   'Open_Palm'],
+  ['gesture_pointing_up', 'Pointing_Up'],
+  ['gesture_thumb_up',    'Thumb_Up'],
+  ['gesture_thumb_down',  'Thumb_Down'],
+  ['gesture_victory',     'Victory'],
+  ['gesture_iloveyou',    'ILoveYou'],
 ];
 
 Blockly.Blocks['init_vision_server'] = {
@@ -12658,7 +12668,7 @@ Blockly.Blocks['init_vision_server'] = {
       .appendField(MSG["vision_init_server_do"]);
     this.setColour("%{BKY_VISION_HUE}");
     this.setPreviousStatement(true, null);
-    this.setTooltip("Cria um servidor HTTP no ESP32 que recebe os eventos de pose enviados pela aba Visão. Conecte ao Wi-Fi antes deste bloco.");
+    this.setTooltip("Cria um servidor HTTP na AMADOBOARD que recebe os eventos de pose ou gesto enviados pela aba Visão. Conecte ao Wi-Fi antes deste bloco.");
     this.setHelpUrl("");
   }
 };
@@ -12676,6 +12686,23 @@ Blockly.Blocks['when_pose_detected'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setTooltip("Executa os blocos filhos quando a pose selecionada for detectada pela aba Visão.");
+    this.setHelpUrl("");
+  }
+};
+
+Blockly.Blocks['when_gesture_detected'] = {
+  init: function() {
+    const opts = GESTURE_OPTIONS.map(([msgKey, value]) => [MSG[msgKey], value]);
+    this.appendDummyInput()
+      .appendField(MSG["vision_when_gesture_title"])
+      .appendField(new Blockly.FieldDropdown(opts), "GESTURE");
+    this.appendStatementInput("DO")
+      .setCheck(null)
+      .appendField(MSG["vision_when_gesture_do"]);
+    this.setColour("%{BKY_VISION_HUE}");
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setTooltip("Executa os blocos filhos quando o gesto de mão selecionado for detectado pela aba Visão.");
     this.setHelpUrl("");
   }
 };

--- a/ui/core/block_definitions.js
+++ b/ui/core/block_definitions.js
@@ -12633,6 +12633,54 @@ Blockly.Blocks['create_list_with_repeated'] = {
 };
 
 
+// ── Visão (Pose) ─────────────────────────────────────────────
+// Lista única de poses — mesmas chaves usadas no gerador Python
+// e no motor de detecção (gesture-control.js).
+const POSE_OPTIONS = [
+  ['pose_arms_up',        'arms_up'],
+  ['pose_t_pose',         't_pose'],
+  ['pose_right_arm_up',   'right_arm_up'],
+  ['pose_left_arm_up',    'left_arm_up'],
+  ['pose_hands_on_head',  'hands_on_head'],
+  ['pose_arms_crossed',   'arms_crossed'],
+];
+
+Blockly.Blocks['init_vision_server'] = {
+  init: function() {
+    this.appendDummyInput()
+      .appendField(MSG["vision_init_server_title"]);
+    this.appendValueInput("port")
+      .setCheck("Number")
+      .setAlign(Blockly.ALIGN_RIGHT)
+      .appendField(MSG["vision_init_server_port"]);
+    this.appendStatementInput("DO")
+      .setCheck(null)
+      .appendField(MSG["vision_init_server_do"]);
+    this.setColour("%{BKY_VISION_HUE}");
+    this.setPreviousStatement(true, null);
+    this.setTooltip("Cria um servidor HTTP no ESP32 que recebe os eventos de pose enviados pela aba Visão. Conecte ao Wi-Fi antes deste bloco.");
+    this.setHelpUrl("");
+  }
+};
+
+Blockly.Blocks['when_pose_detected'] = {
+  init: function() {
+    const opts = POSE_OPTIONS.map(([msgKey, value]) => [MSG[msgKey], value]);
+    this.appendDummyInput()
+      .appendField(MSG["vision_when_pose_title"])
+      .appendField(new Blockly.FieldDropdown(opts), "POSE");
+    this.appendStatementInput("DO")
+      .setCheck(null)
+      .appendField(MSG["vision_when_pose_do"]);
+    this.setColour("%{BKY_VISION_HUE}");
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setTooltip("Executa os blocos filhos quando a pose selecionada for detectada pela aba Visão.");
+    this.setHelpUrl("");
+  }
+};
+
+
 
 
 

--- a/ui/core/generator_stubs.js
+++ b/ui/core/generator_stubs.js
@@ -9625,10 +9625,11 @@ Blockly.Python["create_list_with_repeated"] = function (block) {
 };
 
 
-// ── Visão (Pose) ─────────────────────────────────────────────
+// ── Visão (Pose + Gesto) ─────────────────────────────────────
 // init_vision_server: cria socket TCP, loop accept(), parse do path
-// e delega aos blocos filhos (when_pose_detected) — cada filho
-// gera um "if pose_path == 'pose/<key>':" no mesmo escopo.
+// e delega aos blocos filhos (when_pose_detected, when_gesture_detected)
+// — cada filho gera um "if pose_path == 'pose/<key>':" ou
+// "if pose_path == 'gesture/<key>':" no mesmo escopo.
 
 Blockly.Python["init_vision_server"] = function (block) {
   var port = Blockly.Python.valueToCode(
@@ -9688,6 +9689,18 @@ Blockly.Python["when_pose_detected"] = function (block) {
   }
 
   var code = "if pose_path == 'pose/" + poseKey + "':\n";
+  code += actions;
+  return code;
+};
+
+Blockly.Python["when_gesture_detected"] = function (block) {
+  var gestureKey = block.getFieldValue("GESTURE");
+  var actions = Blockly.Python.statementToCode(block, "DO");
+  if (!actions) {
+    actions = Blockly.Python.INDENT + "pass\n";
+  }
+
+  var code = "if pose_path == 'gesture/" + gestureKey + "':\n";
   code += actions;
   return code;
 };

--- a/ui/core/generator_stubs.js
+++ b/ui/core/generator_stubs.js
@@ -9623,3 +9623,71 @@ Blockly.Python["create_list_with_repeated"] = function (block) {
   const code = `[${item}] * ${num}`;
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
+
+
+// ── Visão (Pose) ─────────────────────────────────────────────
+// init_vision_server: cria socket TCP, loop accept(), parse do path
+// e delega aos blocos filhos (when_pose_detected) — cada filho
+// gera um "if pose_path == 'pose/<key>':" no mesmo escopo.
+
+Blockly.Python["init_vision_server"] = function (block) {
+  var port = Blockly.Python.valueToCode(
+    block,
+    "port",
+    Blockly.Python.ORDER_ATOMIC
+  ) || "80";
+
+  // statementToCode já indenta uma vez; precisamos de mais um nível
+  // (os handlers vivem dentro do try, dentro do while).
+  var handlers = Blockly.Python.statementToCode(block, "DO");
+  if (!handlers) {
+    handlers = Blockly.Python.INDENT + Blockly.Python.INDENT + "pass\n";
+  } else {
+    handlers = Blockly.Python.prefixLines(
+      handlers.replace(/\n$/, ""),
+      Blockly.Python.INDENT
+    ) + "\n";
+  }
+
+  Blockly.Python.definitions_["import_socket"] = "import socket";
+
+  var I = Blockly.Python.INDENT;
+  var code = "";
+  code += "vision_addr = socket.getaddrinfo('0.0.0.0', " + port + ")[0][-1]\n";
+  code += "vision_sock = socket.socket()\n";
+  code += "vision_sock.bind(vision_addr)\n";
+  code += "vision_sock.listen(1)\n";
+  code += "print('BIPES Visao (Pose) escutando em', vision_addr)\n";
+  code += "while True:\n";
+  code += I + "pose_cl, pose_addr = vision_sock.accept()\n";
+  code += I + "pose_path = ''\n";
+  code += I + "try:\n";
+  code += I+I + "pose_file = pose_cl.makefile('rwb', 0)\n";
+  code += I+I + "while True:\n";
+  code += I+I+I + "pose_line = pose_file.readline()\n";
+  code += I+I+I + "if not pose_line or pose_line == b'\\r\\n':\n";
+  code += I+I+I+I + "break\n";
+  code += I+I+I + "pose_lineS = str(pose_line, 'utf8')\n";
+  code += I+I+I + "if pose_lineS.startswith('GET /'):\n";
+  code += I+I+I+I + "pose_path = (pose_lineS.split('/', 1)[1]).split(' ')[0]\n";
+  code += handlers;
+  code += I+I + "pose_cl.send('HTTP/1.0 200 OK\\r\\nContent-Length: 0\\r\\n\\r\\n')\n";
+  code += I + "except Exception as e:\n";
+  code += I+I + "print('Erro Visao:', e)\n";
+  code += I + "finally:\n";
+  code += I+I + "pose_cl.close()\n";
+
+  return code;
+};
+
+Blockly.Python["when_pose_detected"] = function (block) {
+  var poseKey = block.getFieldValue("POSE");
+  var actions = Blockly.Python.statementToCode(block, "DO");
+  if (!actions) {
+    actions = Blockly.Python.INDENT + "pass\n";
+  }
+
+  var code = "if pose_path == 'pose/" + poseKey + "':\n";
+  code += actions;
+  return code;
+};

--- a/ui/msg/en.js
+++ b/ui/msg/en.js
@@ -303,9 +303,20 @@ var MSG = {
   export: "Export",
   saveAMelody: "Save a melody", 
   importAMelody: "Import a melody", 
-  exportAMelody: "Export a melody"
-  
+  exportAMelody: "Export a melody",
 
+  // Vision / Pose
+  vision_init_server_title: "Start Vision (pose server)",
+  vision_init_server_port: "port",
+  vision_init_server_do: "handle poses",
+  vision_when_pose_title: "When I make the pose",
+  vision_when_pose_do: "do",
+  pose_arms_up: "Arms up",
+  pose_t_pose: "Arms open (T)",
+  pose_right_arm_up: "Right arm raised",
+  pose_left_arm_up: "Left arm raised",
+  pose_hands_on_head: "Hands on head",
+  pose_arms_crossed: "Arms crossed"
 };
 
 //Toolbox categories
@@ -334,6 +345,7 @@ Blockly.Msg['CAT_BUZZER'] = "Buzzer";
 Blockly.Msg['CAT_WIFI'] = "Wifi";
 Blockly.Msg['CAT_HTTPCLIENT'] = "HTTP client";
 Blockly.Msg['CAT_HTTPSERVER'] = "HTTP server";
+Blockly.Msg['CAT_VISION'] = "Vision";
 Blockly.Msg['INSTALL_LIBRARY'] = "Install library:"
 Blockly.Msg['PINOUT_LEGEND'] = "Input and Output Pins";
 Blockly.Msg['DHT_SENSOR_LEGEND'] = "DHT11/22 Temperature and Humidity Sensor";

--- a/ui/msg/en.js
+++ b/ui/msg/en.js
@@ -306,17 +306,27 @@ var MSG = {
   exportAMelody: "Export a melody",
 
   // Vision / Pose
-  vision_init_server_title: "Start Vision (pose server)",
+  vision_init_server_title: "Start Vision (server)",
   vision_init_server_port: "port",
-  vision_init_server_do: "handle poses",
-  vision_when_pose_title: "When I make the pose",
+  vision_init_server_do: "handle events",
+  vision_when_pose_title: "When the pose is",
   vision_when_pose_do: "do",
   pose_arms_up: "Arms up",
   pose_t_pose: "Arms open (T)",
   pose_right_arm_up: "Right arm raised",
   pose_left_arm_up: "Left arm raised",
   pose_hands_on_head: "Hands on head",
-  pose_arms_crossed: "Arms crossed"
+  pose_arms_crossed: "Arms crossed",
+  // Vision / Gesture
+  vision_when_gesture_title: "When the gesture is",
+  vision_when_gesture_do: "do",
+  gesture_closed_fist: "Closed fist",
+  gesture_open_palm: "Open palm",
+  gesture_pointing_up: "Pointing up",
+  gesture_thumb_up: "Thumb up",
+  gesture_thumb_down: "Thumb down",
+  gesture_victory: "Victory",
+  gesture_iloveyou: "I love you"
 };
 
 //Toolbox categories

--- a/ui/msg/es.js
+++ b/ui/msg/es.js
@@ -309,8 +309,19 @@ var MSG = {
   saveAMelody: "Guardar una melodía", 
   importAMelody: "Importar una melodía", 
   exportAMelody: "Exportar una melodía",
-  
 
+  // Visión / Pose
+  vision_init_server_title: "Iniciar Visión (servidor de poses)",
+  vision_init_server_port: "puerto",
+  vision_init_server_do: "manejar poses",
+  vision_when_pose_title: "Cuando haga la pose",
+  vision_when_pose_do: "hacer",
+  pose_arms_up: "Brazos arriba",
+  pose_t_pose: "Brazos abiertos (T)",
+  pose_right_arm_up: "Brazo derecho arriba",
+  pose_left_arm_up: "Brazo izquierdo arriba",
+  pose_hands_on_head: "Manos en la cabeza",
+  pose_arms_crossed: "Brazos cruzados"
 };
 
 //Toolbox categories
@@ -339,6 +350,7 @@ Blockly.Msg['CAT_BUZZER'] = "Buzzer";
 Blockly.Msg['CAT_WIFI'] = "Wifi";
 Blockly.Msg['CAT_HTTPCLIENT'] = "cliente HTTP";
 Blockly.Msg['CAT_HTTPSERVER'] = "Servidor HTTP";
+Blockly.Msg['CAT_VISION'] = "Visión";
 Blockly.Msg['INSTALL_LIBRARY'] = "Instalar biblioteca:"
 Blockly.Msg['PINOUT_LEGEND'] = "Pines de entrada y salida";
 Blockly.Msg['DHT_SENSOR_LEGEND'] = "Sensor de temperatura y humedad DHT11/22";

--- a/ui/msg/es.js
+++ b/ui/msg/es.js
@@ -311,9 +311,9 @@ var MSG = {
   exportAMelody: "Exportar una melodía",
 
   // Visión / Pose
-  vision_init_server_title: "Iniciar Visión (servidor de poses)",
+  vision_init_server_title: "Iniciar Visión (servidor)",
   vision_init_server_port: "puerto",
-  vision_init_server_do: "manejar poses",
+  vision_init_server_do: "manejar eventos",
   vision_when_pose_title: "Cuando haga la pose",
   vision_when_pose_do: "hacer",
   pose_arms_up: "Brazos arriba",
@@ -321,7 +321,17 @@ var MSG = {
   pose_right_arm_up: "Brazo derecho arriba",
   pose_left_arm_up: "Brazo izquierdo arriba",
   pose_hands_on_head: "Manos en la cabeza",
-  pose_arms_crossed: "Brazos cruzados"
+  pose_arms_crossed: "Brazos cruzados",
+  // Visión / Gesto
+  vision_when_gesture_title: "Cuando haga el gesto",
+  vision_when_gesture_do: "hacer",
+  gesture_closed_fist: "Puño cerrado",
+  gesture_open_palm: "Mano abierta",
+  gesture_pointing_up: "Apuntando",
+  gesture_thumb_up: "Pulgar arriba",
+  gesture_thumb_down: "Pulgar abajo",
+  gesture_victory: "Victoria",
+  gesture_iloveyou: "Te amo"
 };
 
 //Toolbox categories

--- a/ui/msg/pt-br.js
+++ b/ui/msg/pt-br.js
@@ -303,9 +303,22 @@ var MSG = {
   save: "Salvar",
   import: "Importar", 
   export: "Exportar",
-  saveAMelody: "Salvar uma melodia", 
-  importAMelody: "Importar uma melodia", 
+  saveAMelody: "Salvar uma melodia",
+  importAMelody: "Importar uma melodia",
   exportAMelody: "Exportar uma melodia",
+
+  // Visão / Pose
+  vision_init_server_title: "Iniciar Visão (servidor de poses)",
+  vision_init_server_port: "porta",
+  vision_init_server_do: "tratar poses",
+  vision_when_pose_title: "Quando eu fizer a pose",
+  vision_when_pose_do: "faça",
+  pose_arms_up: "Braços para cima",
+  pose_t_pose: "Braços abertos (T)",
+  pose_right_arm_up: "Braço direito levantado",
+  pose_left_arm_up: "Braço esquerdo levantado",
+  pose_hands_on_head: "Mãos na cabeça",
+  pose_arms_crossed: "Braços cruzados",
 };
 
 //Categorias da caixa de ferramentas
@@ -335,6 +348,7 @@ Blockly.Msg['CAT_BUZZER'] = "Campainha";
 Blockly.Msg['CAT_WIFI'] = "WiFi";
 Blockly.Msg['CAT_HTTPCLIENT'] = "Cliente HTTP";
 Blockly.Msg['CAT_HTTPSERVER'] = "Servidor HTTP"
+Blockly.Msg['CAT_VISION'] = "Visão"
 Blockly.Msg['INSTALL_LIBRARY'] = "Instalar biblioteca:"
 Blockly.Msg['PINOUT_LEGEND'] = "Pinos de entrada e saída"
 Blockly.Msg['DHT_SENSOR_LEGEND'] = "Sensor de temperatura e umidade DHT11/22";

--- a/ui/msg/pt-br.js
+++ b/ui/msg/pt-br.js
@@ -311,7 +311,7 @@ var MSG = {
   vision_init_server_title: "Iniciar Visão (servidor de poses)",
   vision_init_server_port: "porta",
   vision_init_server_do: "tratar poses",
-  vision_when_pose_title: "Quando eu fizer a pose",
+  vision_when_pose_title: "Quando fizer a pose",
   vision_when_pose_do: "faça",
   pose_arms_up: "Braços para cima",
   pose_t_pose: "Braços abertos (T)",

--- a/ui/msg/pt-br.js
+++ b/ui/msg/pt-br.js
@@ -308,9 +308,9 @@ var MSG = {
   exportAMelody: "Exportar uma melodia",
 
   // Visão / Pose
-  vision_init_server_title: "Iniciar Visão (servidor de poses)",
+  vision_init_server_title: "Iniciar Visão (servidor)",
   vision_init_server_port: "porta",
-  vision_init_server_do: "tratar poses",
+  vision_init_server_do: "tratar eventos",
   vision_when_pose_title: "Quando fizer a pose",
   vision_when_pose_do: "faça",
   pose_arms_up: "Braços para cima",
@@ -319,6 +319,16 @@ var MSG = {
   pose_left_arm_up: "Braço esquerdo levantado",
   pose_hands_on_head: "Mãos na cabeça",
   pose_arms_crossed: "Braços cruzados",
+  // Visão / Gesto
+  vision_when_gesture_title: "Quando fizer o gesto",
+  vision_when_gesture_do: "faça",
+  gesture_closed_fist: "Punho fechado",
+  gesture_open_palm: "Mão aberta",
+  gesture_pointing_up: "Apontando",
+  gesture_thumb_up: "Polegar para cima",
+  gesture_thumb_down: "Polegar para baixo",
+  gesture_victory: "Vitória",
+  gesture_iloveyou: "Eu te amo",
 };
 
 //Categorias da caixa de ferramentas

--- a/ui/msg/pt.js
+++ b/ui/msg/pt.js
@@ -306,6 +306,19 @@ var MSG = {
   saveAMelody: "Guardar uma melodia",
   importAMelody: "Importar uma melodia",
   exportAMelody: "Exportar uma melodia",
+
+  // Visão / Pose
+  vision_init_server_title: "Iniciar Visão (servidor de poses)",
+  vision_init_server_port: "porta",
+  vision_init_server_do: "tratar poses",
+  vision_when_pose_title: "Quando eu fizer a pose",
+  vision_when_pose_do: "fazer",
+  pose_arms_up: "Braços para cima",
+  pose_t_pose: "Braços abertos (T)",
+  pose_right_arm_up: "Braço direito levantado",
+  pose_left_arm_up: "Braço esquerdo levantado",
+  pose_hands_on_head: "Mãos na cabeça",
+  pose_arms_crossed: "Braços cruzados",
 };
 
 // Categorias da caixa de ferramentas
@@ -335,6 +348,7 @@ Blockly.Msg["CAT_BUZZER"] = "Campainha";
 Blockly.Msg["CAT_WIFI"] = "Wi-Fi";
 Blockly.Msg["CAT_HTTPCLIENT"] = "Cliente HTTP";
 Blockly.Msg["CAT_HTTPSERVER"] = "Servidor HTTP";
+Blockly.Msg["CAT_VISION"] = "Visão";
 Blockly.Msg["INSTALL_LIBRARY"] = "Instalar biblioteca:";
 Blockly.Msg["PINOUT_LEGEND"] = "Pinos de entrada e saída";
 Blockly.Msg["DHT_SENSOR_LEGEND"] = "Sensor de temperatura e humidade DHT11/22";

--- a/ui/msg/pt.js
+++ b/ui/msg/pt.js
@@ -311,7 +311,7 @@ var MSG = {
   vision_init_server_title: "Iniciar Visão (servidor de poses)",
   vision_init_server_port: "porta",
   vision_init_server_do: "tratar poses",
-  vision_when_pose_title: "Quando eu fizer a pose",
+  vision_when_pose_title: "Quando fizer a pose",
   vision_when_pose_do: "fazer",
   pose_arms_up: "Braços para cima",
   pose_t_pose: "Braços abertos (T)",

--- a/ui/msg/pt.js
+++ b/ui/msg/pt.js
@@ -308,9 +308,9 @@ var MSG = {
   exportAMelody: "Exportar uma melodia",
 
   // Visão / Pose
-  vision_init_server_title: "Iniciar Visão (servidor de poses)",
+  vision_init_server_title: "Iniciar Visão (servidor)",
   vision_init_server_port: "porta",
-  vision_init_server_do: "tratar poses",
+  vision_init_server_do: "tratar eventos",
   vision_when_pose_title: "Quando fizer a pose",
   vision_when_pose_do: "fazer",
   pose_arms_up: "Braços para cima",
@@ -319,6 +319,16 @@ var MSG = {
   pose_left_arm_up: "Braço esquerdo levantado",
   pose_hands_on_head: "Mãos na cabeça",
   pose_arms_crossed: "Braços cruzados",
+  // Visão / Gesto
+  vision_when_gesture_title: "Quando fizer o gesto",
+  vision_when_gesture_do: "fazer",
+  gesture_closed_fist: "Punho fechado",
+  gesture_open_palm: "Mão aberta",
+  gesture_pointing_up: "A apontar",
+  gesture_thumb_up: "Polegar para cima",
+  gesture_thumb_down: "Polegar para baixo",
+  gesture_victory: "Vitória",
+  gesture_iloveyou: "Adoro-te",
 };
 
 // Categorias da caixa de ferramentas

--- a/ui/toolbox/AmadoBoard.xml
+++ b/ui/toolbox/AmadoBoard.xml
@@ -2409,7 +2409,7 @@ _
 
 <category name="%{BKY_CAT_VISION}" colour="%{BKY_VISION_HUE}">
   <label text="Visão por Câmera"></label>
-  <label text="Use os blocos abaixo para reagir a poses corporais detectadas pela aba Visão."></label>
+  <label text="Use os blocos abaixo para reagir a poses corporais ou gestos de mão detectados pela aba Visão."></label>
   <label text="Antes deste bloco, conecte a placa ao Wi-Fi."></label>
   <block type="init_vision_server">
     <value name="port">
@@ -2419,6 +2419,7 @@ _
     </value>
   </block>
   <block type="when_pose_detected"></block>
+  <block type="when_gesture_detected"></block>
 </category>
 
 <!--Comentando a categoria Control para PID-->

--- a/ui/toolbox/AmadoBoard.xml
+++ b/ui/toolbox/AmadoBoard.xml
@@ -2407,6 +2407,20 @@ _
     -->
 </category>
 
+<category name="%{BKY_CAT_VISION}" colour="%{BKY_VISION_HUE}">
+  <label text="Visão por Câmera"></label>
+  <label text="Use os blocos abaixo para reagir a poses corporais detectadas pela aba Visão."></label>
+  <label text="Antes deste bloco, conecte a placa ao Wi-Fi."></label>
+  <block type="init_vision_server">
+    <value name="port">
+      <shadow type="math_number">
+        <field name="NUM">80</field>
+      </shadow>
+    </value>
+  </block>
+  <block type="when_pose_detected"></block>
+</category>
+
 <!--Comentando a categoria Control para PID-->
 <!--
 <category name="%{BKY_CAT_CONTROL}">


### PR DESCRIPTION
## Resumo

  Adiciona detecção de pose corporal e blocos da categoria **Visão**, além de espelhar o
  caminho dos blocos para os gestos de mão.

  ## O que foi feito

  - Toggle **Mãos / Corpo** no HUD da aba Visão (mutuamente exclusivo).
  - Detecção de 6 poses corporais via MediaPipe Pose.
  - Modal **Definir Poses** reaproveitando o de gestos.
  - Categoria **Visão** no toolbox com três blocos: `Iniciar Visão (servidor)`, `Quando fizer
  a pose [X]` e `Quando fizer o gesto [X]`.
  - Endpoint default `/pose/<key>` e `/gesture/<key>` enviados automaticamente quando o card
  do modal está vazio — caminho dos blocos funciona out of the box.
  - Labels da UI atualizadas pra **AMADOBOARD** no lugar de ESP32.
  - Botões `Testar`, `Mãos` e `Corpo` sem emoji.
  - `ROADMAP.md` com três frentes de evolução futura.