### PR TITLE
fix: impede que erro no bipesVerify derrube a leitura serial

### DIFF
--- a/ui/core/utils.js
+++ b/ui/core/utils.js
@@ -273,7 +273,16 @@ class Tool {
         let coordinates = match_[2]
           .split(",")
           .map((item) => (item = parseFloat(item)));
-        window.frames[3].modules.DataStorage.push(match_[1], coordinates);
+        // Envia para o DataStorage do databoard. Mira pelo id (não por window.frames[N],
+        // que quebra ao adicionar/reordenar iframes) e protege com try/catch: este trecho
+        // roda dentro do write() do stream WebSerial — um erro aqui abortaria a leitura da
+        // serial e congelaria o console após o primeiro "$BIPES-DATA:".
+        try {
+          let databoardWin = document.getElementById("databoard_iframe");
+          databoardWin = databoardWin && databoardWin.contentWindow;
+          if (databoardWin && databoardWin.modules && databoardWin.modules.DataStorage)
+            databoardWin.modules.DataStorage.push(match_[1], coordinates);
+        } catch (e) { /* databoard indisponível: ignora para não derrubar a serial */ }
 
         /*STARTDEPRECATED*/
         //Compatibilty layer with the old BIPES-DATA:INDEX,DATA


### PR DESCRIPTION
O bloco "mostrar na aba IoT" faz a placa imprimir linhas "$BIPES-DATA:", processadas por Tool.bipesVerify(). Essa função acessava window.frames[3].modules.DataStorage.push(...) sem proteção, mas frames[3] deixou de ser o iframe do databoard (iframes adicionados nesta branch deslocaram o índice), virando o simulador, que não tem DataStorage.

No caminho WebSerial isso roda dentro do write() do stream: a exceção abortava o pipeTo e matava a leitura da serial, congelando o console (e o estado do botão de run) após a primeira linha "$BIPES-DATA:".

Agora o iframe do databoard é alvo pelo id (não por window.frames[N], frágil a reordenação) e a chamada fica protegida por try/catch, para que um erro de UI nunca mais derrube o stream serial.