### PR TITLE
fix: gera client_id MQTT único por placa no bloco EasyMQTT Start

### DIFF
--- a/ui/core/generator_stubs.js
+++ b/ui/core/generator_stubs.js
@@ -1187,10 +1187,12 @@ Blockly.Python["easymqtt_init"] = function (block) {
   window.easyMQTT_session = session;
 
   Blockly.Python.definitions_["import_umqtt.robust"] = "import umqtt.robust";
+  Blockly.Python.definitions_["import_machine"] = "import machine";
+  Blockly.Python.definitions_["import_ubinascii"] = "import ubinascii";
   var code =
     'easymqtt_session = "' +
     session +
-    '"; \neasymqtt_client = umqtt.robust.MQTTClient("umqtt_client", server = ' +
+    '"; \neasymqtt_client = umqtt.robust.MQTTClient(b"bipes-"+ubinascii.hexlify(machine.unique_id()), server = ' +
     server +
     ", port = " +
     port +


### PR DESCRIPTION
O easymqtt_init gerava sempre MQTTClient("umqtt_client", ...) com id fixo. Em ambientes com várias placas (ex.: formações), todas conectavam ao broker com o mesmo client_id e o broker, que só aceita uma conexão por id, derrubava umas às outras — causando recepção/publicação intermitente para todos.

Agora o id é derivado de machine.unique_id() (b"bipes-"+hexlify), único por dispositivo, e os imports de machine/ubinascii são adicionados.