### PR TITLE
273 fix botao play

### DIFF
--- a/docs/TODO-easymqtt-html-dominio-proprio.md
+++ b/docs/TODO-easymqtt-html-dominio-proprio.md
@@ -1,0 +1,79 @@
+# TODO: corrigir `easymqtt/easymqtt.html` (link de dashboard no domínio próprio)
+
+**Status:** pendente — adiado para depois
+**Data do registro:** 2026-06-03
+**Branch atual quando identificado:** `269-feat-visao-landmarks-como-variavel`
+
+## Objetivo
+
+Ter um link de compartilhamento do dashboard EasyMQTT **no nosso próprio domínio**, no padrão:
+
+```
+https://staging.dblocks.com.br/easymqtt/easymqtt.html?session=<SESSION_ID>
+https://dblocks.com.br/easymqtt/easymqtt.html?session=<SESSION_ID>   (produção)
+```
+
+A página `easymqtt/easymqtt.html` já existe e é um "embrulho" (wrapper) que embute o dashboard
+do `bipes-api` num `<iframe>` — mesma técnica usada na aba MQTT do app (`ui/index.html`).
+
+## O problema
+
+O wrapper ficou pela metade. Em `easymqtt/easymqtt.html` (linha ~40) o iframe aponta para
+desenvolvimento local:
+
+```js
+iframe.src = `http://localhost:3000/?session=${session}`;
+```
+
+Como `localhost:3000` é resolvido na máquina de **quem abre o link**, o dashboard não carrega
+para ninguém além de um ambiente de dev local. Por isso
+`https://staging.dblocks.com.br/easymqtt/easymqtt.html?session=...` não mostra dados.
+
+> Obs.: a outra página, `easymqtt/index.html`, é a versão **antiga em PHP** (`getsession.php` etc.)
+> e está quebrada neste deploy — o `Dockerfile` da raiz instala só `apache2 openssl`, sem PHP,
+> então os `.php` voltam como fonte crua e dão `parsererror: Unexpected token '<'`. Não usar.
+
+## A correção proposta
+
+Trocar o `localhost:3000` pela URL do `bipes-api` com detecção de ambiente, igual ao que
+`ui/index.html` (`abrirEasyMQTT`, ~linha 382-394) já faz:
+
+```js
+function abrirEasyMQTT() {
+  const params = new URLSearchParams(window.location.search);
+  const session = params.get("session");
+  const iframe = document.getElementById('easymqtt_iframe');
+
+  const host = window.location.hostname;
+  const apiUrl = host.includes('staging') || host.includes('localhost') || host.includes('127.0.0.1')
+    ? 'https://bipes-api-staging-tgtka7akja-uc.a.run.app'
+    : 'https://bipes-api-tgtka7akja-uc.a.run.app';
+
+  iframe.src = session ? `${apiUrl}/?session=${session}` : `${apiUrl}/`;
+}
+```
+
+Depois disso, o link no domínio próprio funciona em staging e produção automaticamente.
+
+## Por que NÃO foi resolvido agora
+
+A branch ativa (`269-feat-visao-landmarks-como-variavel`) é da feature de **Visão/landmarks**.
+Aplicar essa correção de EasyMQTT aqui misturaria assuntos não relacionados no mesmo PR,
+dificultando a revisão e o merge. O correto é fazer numa branch dedicada a partir da `master`
+(ex.: `fix/easymqtt-html-aponta-bipes-api`).
+
+## Como prosseguir (quando voltar)
+
+1. `git checkout master && git pull`
+2. `git checkout -b fix/easymqtt-html-aponta-bipes-api`
+3. Aplicar a correção acima em `easymqtt/easymqtt.html`.
+4. Testar: `https://staging.dblocks.com.br/easymqtt/easymqtt.html?session=luzSala` deve mostrar os dados.
+5. PR para a `staging` → validar → produção.
+
+## Alternativa / workaround válido hoje
+
+Enquanto isso, o link de compartilhamento que **já funciona** é o do `bipes-api` direto:
+
+```
+https://bipes-api-staging-tgtka7akja-uc.a.run.app/?session=<SESSION_ID>
+```

--- a/docs/fix-botao-play-maquina-de-estados.md
+++ b/docs/fix-botao-play-maquina-de-estados.md
@@ -1,0 +1,73 @@
+# Correção do botão Play (Run/Stop)
+
+**Status:** feito e testado (WebSerial/USB e WebSocket/EasyMQTT)
+**Data:** 2026-06-08
+**Branch:** `273-fix-botao-play`
+**Commit:** `1c3f33e`
+**Arquivos:** `ui/core/ui.js`, `ui/core/channel.js`
+
+## O problema (sintomas)
+
+O botão Play travava com frequência — muitas vezes só recarregando a página (F5) ele voltava.
+Outros sintomas:
+
+- Rodando um programa em loop, o botão **não pausava**.
+- Apertar **reset "ativava"** o botão sozinho.
+- Qualquer dado vindo da placa colocava o botão em "rodando" mesmo sem nada rodar.
+- Às vezes era preciso **clicar várias vezes** pra ele "destravar".
+- Funcionava pra uma pessoa e falhava pra outra (intermitente).
+
+Já tinha sido "consertado" várias vezes antes (PRs #240, #242, #243, #264, #265, #267),
+sempre na mesma região — sinal de que o problema era de **arquitetura**, não um bug pontual.
+
+## Como era antes (a causa raiz)
+
+O estado do botão era **adivinhado lendo a saída serial da placa**. Existia uma única
+variável (`runButton.status`) e o código ficava procurando o texto `">>> "` (o prompt do
+MicroPython) no que a placa imprimia pra decidir se o botão era "▶ rodar" ou "⏹ parar".
+
+Essa lógica estava **copiada e idêntica nos 3 canais** (WebSerial, WebSocket, Bluetooth),
+com dois defeitos centrais:
+
+1. **Qualquer dado recebido** com o botão ocioso já o jogava pra "rodando" (mensagem de boot,
+   debug, echo). Aí o clique não fazia o esperado.
+2. **Se o programa entrava em loop**, a placa nunca mais imprimia `">>> "` — então o botão
+   ficava **preso pra sempre** em "rodando". Esse era o travamento que exigia F5.
+
+Como dependia de *timing* da serial, era não-determinístico: funcionava num momento,
+travava no outro, e variava de máquina pra máquina.
+
+## Como ficou (a correção)
+
+O estado do botão passou a ser uma **máquina de estados explícita**, dirigida pela
+**intenção do usuário**, não pelo texto da serial. Quatro estados:
+`disconnected` → `idle` → `running` → `stopping`.
+
+Peças novas em `ui/core/ui.js`:
+
+- **`setRunState(estado)`** — fonte única da verdade do botão. Tudo que muda o botão passa
+  por aqui.
+- **`onReplPrompt()`** — o `">>> "` virou só uma **confirmação** de que a placa voltou ao
+  prompt. Ele leva "rodando → pronto" e **nunca mexe num botão que já está pronto** (foi isso
+  que acabou com o reset/boot bagunçando o botão).
+- **`run()` (o clique)** — ao **parar**, devolve a UI pra "pronto" **na hora** (otimista).
+  Assim o botão **nunca fica preso**, mesmo com a placa num loop infinito. Foi isso que
+  eliminou o travamento que exigia recarregar a página.
+
+Em `ui/core/channel.js`: removida a lógica frágil ("vilão") nos 3 canais; a detecção do
+prompt agora chama o `onReplPrompt()`; conectar marca "pronto" em vez de "rodando".
+
+## Antes × Depois (resumo)
+
+| Situação | Antes | Depois |
+|---|---|---|
+| Programa em loop infinito | Botão preso → **F5** | Para na hora, botão volta a "pronto" |
+| Apertar reset | Botão "ativava" sozinho | Reset não mexe mais no botão |
+| Dado chegando da placa | Jogava pra "rodando" | Não muda o botão |
+| Consistência | Dependia de timing (intermitente) | Determinístico — sempre igual |
+
+## Por que ficou confiável
+
+Antes o botão **adivinhava** o estado a partir de algo incerto (quando/se o `">>> "` chegava).
+Agora ele **decide** com base no que você fez (clicou rodar / clicou parar). Não sobrou nada
+"indeterminado" pra dar errado — por isso passou a funcionar sempre igual.

--- a/ui/core/channel.js
+++ b/ui/core/channel.js
@@ -223,6 +223,7 @@ class websocket {
 
       this.connected = true;
       UI ['workspace'].websocket.url.disabled = true;
+      UI ['workspace'].setRunState ('idle');
       this.last4chars = '';
 
       this.ws.onmessage = (event) => {
@@ -311,9 +312,7 @@ class websocket {
           Tool.bipesVerify ();
           this.last4chars = (this.last4chars + event.data).slice(-4);
           if (event.data.includes(">>> ") || this.last4chars.includes(">>> ")) {
-            UI ['workspace'].runButton.status = true;
-            UI ['workspace'].runButton.dom.className = 'icon';
-            UI ['workspace'].toolbarButton.className = 'icon medium';
+            UI ['workspace'].onReplPrompt ();
             if (this.completeBufferCallback.length > 0) {
               try {
                 this.completeBufferCallback [0] ();
@@ -325,8 +324,6 @@ class websocket {
           } else if (event.data.includes("Access denied")) {
             //WebSocket might close before receiving this message, so won't trigger.
             UI ['notify'].send("Wrong board password.");
-          } else if (UI ['workspace'].runButton.status == true) {
-            UI ['workspace'].receiving ();
           }
         }
         Files.received_string = Files.received_string.concat(event.data);
@@ -428,9 +425,7 @@ class webserial {
                 //data comes in chunks, keep last 4 chars to check MicroPython REPL string
                 Channel ['webserial'].last4chars = Channel ['webserial'].last4chars.concat(chunk.substr(-4,4)).substr(-4,4)
                 if (Channel ['webserial'].last4chars.includes(">>> ")) {
-                  UI ['workspace'].runButton.status = true;
-                  UI ['workspace'].runButton.dom.className = 'icon';
-                  UI ['workspace'].toolbarButton.className = 'icon medium';
+                  UI ['workspace'].onReplPrompt ();
                   if (Channel ['webserial'].completeBufferCallback.length > 0) {
                     try {
                       Channel ['webserial'].completeBufferCallback [0] ();
@@ -439,8 +434,6 @@ class webserial {
                     }
                     Channel ['webserial'].completeBufferCallback.shift ();
                   }
-                } else if (UI ['workspace'].runButton.status == true) {
-                  UI ['workspace'].receiving ();
                 }
                 Files.received_string = Files.received_string.concat(chunk);
               }
@@ -477,8 +470,7 @@ class webserial {
     term.on();
     term.write('\x1b[31mConnected using Web Serial API !\x1b[m\r\n');
     this.connected=true;
-    if (UI ['workspace'].runButton.status == true)
-        UI ['workspace'].receiving ();
+    UI ['workspace'].setRunState ('idle');
 
     this.watcher = setInterval(this.watch.bind(this), 50);
   }
@@ -756,8 +748,7 @@ class webbluetooth {
         term.write('\x1b[31mConnected using Web Bluetooth API !\x1b[m\r\n');
         this.connected = true;
         mux.bufferPush ('\r');
-        if (UI ['workspace'].runButton.status == true)
-          UI ['workspace'].receiving ();
+        UI ['workspace'].setRunState ('idle');
         this.watcher = setInterval(this.watch.bind(this), 50);
       }).catch(error => {
         UI ['notify'].log(error);
@@ -808,9 +799,7 @@ class webbluetooth {
     //data comes in chunks, keep last 4 chars to check MicroPython REPL string
     this.last4chars = this.last4chars.concat(chunk.substr(-4,4)).substr(-4,4)
     if (this.last4chars.includes(">>> ")) {
-      UI ['workspace'].runButton.status = true;
-      UI ['workspace'].runButton.dom.className = 'icon';
-      UI ['workspace'].toolbarButton.className = 'icon medium';
+      UI ['workspace'].onReplPrompt ();
       if (this.completeBufferCallback.length > 0) {
         try {
           this.completeBufferCallback [0] ();
@@ -819,8 +808,6 @@ class webbluetooth {
         }
         this.completeBufferCallback.shift ();
       }
-    } else if (UI ['workspace'].runButton.status == true) {
-      UI ['workspace'].receiving ();
     }
     Files.received_string = Files.received_string.concat(chunk);
   }

--- a/ui/core/ui.js
+++ b/ui/core/ui.js
@@ -497,6 +497,10 @@ class workspace {
         dom:get('#runButton'),
         status:true
       };
+    /** Authoritative Run/Stop button state, driven by user intent and the
+     * confirmed command lifecycle. One of 'disconnected'|'idle'|'running'|
+     * 'stopping'. See :js:func:`workspace#setRunState`. */
+    this.runState = 'disconnected';
     this.connectButton = get('#connectButton');
     this.saveButton = get('#saveButton');
     this.loadButton = get('#loadXML');
@@ -524,16 +528,90 @@ class workspace {
  * DOM `#runButton`. If not connection, will try to connect then run.
  */
 workspace.prototype.run = function () {
-  if (this.runButton.status) {
-    if(mux.connected ()) {
+  switch (this.runState) {
+    case 'running':
+    case 'stopping':
+      // User asked to stop. stopPython() queues Ctrl+C at the FRONT of the
+      // buffer, then we optimistically return the UI to "ready" right away —
+      // so the button is usable again even if the board is stuck in a loop and
+      // never echoes ">>> ". This is what stops the "have to refresh the page"
+      // freeze.
+      Tool.stopPython();
+      this.setRunState('idle');
+      break;
+    case 'idle':
+      this.setRunState('running');
+      Tool.runPython();
+      break;
+    default: // 'disconnected' (or any unexpected state): connect, then run
+      if (mux.connected ()) {
+        this.setRunState('running');
         Tool.runPython();
-    } else {
-      Channel ['mux'].connect ();
-      setTimeout(() => { if (mux.connected ()) Tool.runPython();}, 2000);
-    }
-  } else {
-    Tool.stopPython();
+      } else {
+        Channel ['mux'].connect ();
+        setTimeout(() => {
+          if (mux.connected ()) {
+            this.setRunState('running');
+            Tool.runPython();
+          }
+        }, 2000);
+      }
+      break;
   }
+}
+
+/**
+ * Single source of truth for the Run/Stop button styling and state. Driven by
+ * user intent and the confirmed command lifecycle — NOT by string-matching the
+ * serial output. Keeps the legacy :js:attr:`workspace#runButton`.status boolean
+ * in sync (true = clicking runs, false = clicking stops) for code that reads it.
+ * @param {('disconnected'|'idle'|'running'|'stopping')} state
+ */
+workspace.prototype.setRunState = function (state) {
+  this.runState = state;
+  switch (state) {
+    case 'idle': // connected, at REPL prompt, ready to run
+      this.runButton.status = true;
+      this.runButton.dom.className = 'icon';
+      this.toolbarButton.className = 'icon medium';
+      this.channel_connect.className = '';
+      this.connectButton.className = 'icon on';
+      this.term.className = 'on';
+      break;
+    case 'running':
+    case 'stopping':
+      this.runButton.status = false;
+      this.runButton.dom.className = 'icon on';
+      this.toolbarButton.className = 'icon medium on';
+      this.channel_connect.className = '';
+      this.connectButton.className = 'icon on';
+      this.term.className = 'on';
+      break;
+    case 'disconnected':
+    default:
+      this.runState = 'disconnected';
+      this.runButton.status = true;
+      this.runButton.dom.className = 'icon';
+      this.toolbarButton.className = 'icon medium';
+      this.channel_connect.className = '';
+      this.connectButton.className = 'icon';
+      this.term.className = '';
+      this.websocket.url.disabled = false;
+      this.connectButton.value = "Connect";
+      break;
+  }
+}
+
+/**
+ * Called by the comms channels when the MicroPython REPL prompt (">>> ") shows
+ * up in the serial output. This is now only a CONFIRMATION that the board is
+ * back at the prompt: it moves a running/stopping program to idle and never
+ * touches an already-idle button. This kills the old yo-yo where boot banners,
+ * prints, or a reset would flip the button on their own.
+ */
+workspace.prototype.onReplPrompt = function () {
+  if (this.runState === 'running' || this.runState === 'stopping')
+    this.setRunState('idle');
 }
 
 /**
@@ -559,26 +637,14 @@ workspace.prototype.connectClick = function () {
  * Switch on styling for connected to device.
  */
 workspace.prototype.receiving = function () {
-  this.channel_connect.className = '';
-  this.runButton.status = false;
-  this.runButton.dom.className = 'icon on';
-  this.toolbarButton.className = 'icon medium on';
-  this.connectButton.className = 'icon on';
-  this.term.className = 'on';
+  this.setRunState('running');
 }
 
 /**
- * Switch off styling for connected to device.
+ * Switch off styling: connection is gone. Routes through the state machine.
  */
 workspace.prototype.runAbort = function () {
-  this.channel_connect.className = '';
-  this.runButton.status = true;
-  this.runButton.dom.className = 'icon';
-  this.toolbarButton.className = 'icon medium';
-  this.connectButton.className = 'icon';
-  this.term.className = '';
-  this.websocket.url.disabled = false;
-  this.connectButton.value = "Connect";
+  this.setRunState('disconnected');
 }
 
 /**


### PR DESCRIPTION
 ## Corrige o travamento do botão Play (Run/Stop)

  ### Problema
  O botão Play travava com frequência — muitas vezes só
  recarregando a página (F5) ele voltava. Também não pausava
  programas em loop, o reset "ativava" o botão sozinho, e às
  vezes era preciso clicar várias vezes pra destravar. Era
  intermitente: funcionava pra uns e falhava pra outros.

  ### Causa
  O estado do botão era **adivinhado lendo a saída serial**
  (procurando o prompt `">>> "` do MicroPython), com a lógica
  copiada nos 3 canais (WebSerial, WebSocket, Bluetooth).
  Como dependia de *timing*, dessincronizava com facilidade.

  ### Solução
  Troquei essa adivinhação por uma **máquina de estados
  explícita**, dirigida pela **intenção do usuário** (clicou
  rodar → roda; clicou parar → para e a UI volta na hora). O
  prompt `">>> "` virou só uma confirmação, nunca o motor.

  ### Mudanças
  - `ui/core/ui.js` — máquina de estados (`setRunState`,
  `onReplPrompt`, `run` otimista)
  - `ui/core/channel.js` — remove a lógica frágil nos 3
  canais; usa o novo fluxo
  - `docs/` — documentação do conserto + registro do TODO do
  EasyMQTT

  ### Testado
  - ✅ WebSerial (USB) — rodar, parar loop infinito, reset,
  estresse de rodar/parar (sem F5)
  - ✅ WebSocket (aba EasyMQTT)

  ### Antes × Depois
  | Situação | Antes | Depois |
  |---|---|---|
  | Programa em loop | Botão preso → F5 | Para na hora |
  | Apertar reset | Botão "ativava" sozinho | Não mexe no
  botão |
  | Consistência | Intermitente (timing) | Determinístico |