### PR TITLE
fix(infra): habilita cpu_idle nos serviços Cloud Run

### DIFF
--- a/infra/terraform/modules/subscriber/main.tf
+++ b/infra/terraform/modules/subscriber/main.tf
@@ -25,6 +25,7 @@ resource "google_cloud_run_v2_service" "subscriber" {
           cpu    = "1"
           memory = "512Mi"
         }
+        cpu_idle = true
       }
     }
 

--- a/infra/terraform/modules/ui/main.tf
+++ b/infra/terraform/modules/ui/main.tf
@@ -26,6 +26,7 @@ resource "google_cloud_run_v2_service" "ui" {
           cpu    = "1"
           memory = "512Mi"
         }
+        cpu_idle = true
       }
     }
 


### PR DESCRIPTION
cpu-throttling estava desabilitado em bipes-ui e bipes-subscriber, fazendo o Cloud Run cobrar CPU integral mesmo entre requisições. Com cpu_idle=true, o billing passa a ser apenas durante o processamento de requests.

Serviços corrigidos: bipes-ui, bipes-subscriber (staging + prod)
Não afetado: mqtt-publisher (Cloud Function v2, throttling já correto)