### PR TITLE
fix(easymqtt): substitui URLs hardcoded do bipes-api por window.locat…

### DIFF
--- a/ui/easymqtt_bridge.html
+++ b/ui/easymqtt_bridge.html
@@ -39,8 +39,7 @@
       function action3() {
         var session = localStorage.getItem("bridgeSession");
         window.open(
-          "https://bipes-api-143389608818.us-central1.run.app/?session=" +
-            session
+          window.location.origin + "/easymqtt/?session=" + session
         );
       }
     </script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -378,25 +378,12 @@ function abrirEasyMQTT() {
     const session = window.easyMQTT_session;
     const iframe = document.getElementById('easymqtt_iframe');
     
-    // Detecta automaticamente o ambiente baseado na URL atual
-    const currentHost = window.location.hostname;
-    let apiUrl;
-    
-    if (currentHost.includes('staging')) {
-        // Se a UI for staging, usar API staging
-        apiUrl = 'https://bipes-api-staging-tgtka7akja-uc.a.run.app';
-    } else if (currentHost.includes('localhost') || currentHost.includes('127.0.0.1')) {
-        // Para desenvolvimento local, usar staging como padrão
-        apiUrl = 'https://bipes-api-staging-tgtka7akja-uc.a.run.app';
-    } else {
-        // Para production ou qualquer outro ambiente
-        apiUrl = 'https://bipes-api-tgtka7akja-uc.a.run.app';
-    }
+    const easymqttUrl = `${window.location.origin}/easymqtt`;
 
     if (session) {
-        iframe.src = `${apiUrl}/?session=${session}`;
+        iframe.src = `${easymqttUrl}/?session=${session}`;
     } else {
-        iframe.src = `${apiUrl}/`;
+        iframe.src = `${easymqttUrl}/`;
         console.warn('Sessão não definida. Abrindo EasyMQTT sem sessão.');
     }
     


### PR DESCRIPTION
…ion.origin

O serviço bipes-api não existe mais — o easymqtt/ é servido pelo bipes-ui. Usando window.location.origin o link funciona automaticamente em staging, prod e localhost.